### PR TITLE
Feature/#9 jpa auditing with hello entiy

### DIFF
--- a/src/main/java/com/dykim/base/BaseApplication.java
+++ b/src/main/java/com/dykim/base/BaseApplication.java
@@ -2,7 +2,9 @@ package com.dykim.base;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class BaseApplication {
 

--- a/src/main/java/com/dykim/base/hello/v1/config/HelloAuditorAware.java
+++ b/src/main/java/com/dykim/base/hello/v1/config/HelloAuditorAware.java
@@ -1,0 +1,36 @@
+package com.dykim.base.hello.v1.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+/**
+ * <h3>HelloBaseEntity Auditor 설정</h3>
+ * JPA Auditing 에서 아래 어노테이션이 붙은 컬럼에 삽입될 값을 정의한다.
+ * <pre>
+ * 1. @CreatedBy - session user Id
+ * 2. @LastModifiedBy - session user Id
+ * </pre>
+ */
+@RequiredArgsConstructor
+@Component
+public class HelloAuditorAware implements AuditorAware<Long> {
+
+    /**
+     * TODO: 로그인 구현 후 아래 세션 객체 사용필요.
+     * HttpSession: 인터셉터를 통해 세션 검증 후 들어오기 때문에 리퀘스트부터 검증할 필요는 없음.<p/>
+     * HttpServletRequest: invalid 세션인 경우 HttpSession 바로 사용 시 예외가 발생하기 때문에 검증이 필요할 수도 있음.<p/>
+     * 위 케이스를 대비하여 두 가지 객체를 주석으로 추가함.
+     */
+//    private HttpSession httpSession;
+//    private HttpServletRequest httpServletRequest;
+
+    @Override
+    public Optional<Long> getCurrentAuditor() {
+        final var MOCK_SESSION_USER_ID = 2483L;
+        return Optional.of(MOCK_SESSION_USER_ID);
+    }
+
+}

--- a/src/main/java/com/dykim/base/hello/v1/controller/advice/HelloControllerAdvice.java
+++ b/src/main/java/com/dykim/base/hello/v1/controller/advice/HelloControllerAdvice.java
@@ -2,6 +2,7 @@ package com.dykim.base.hello.v1.controller.advice;
 
 import com.dykim.base.hello.v1.controller.HelloController;
 import com.dykim.base.hello.v1.controller.advice.exception.HelloAlreadyExistException;
+import com.dykim.base.hello.v1.controller.advice.exception.HelloAuditorAwareException;
 import com.dykim.base.hello.v1.controller.advice.exception.HelloException;
 import com.dykim.base.hello.v1.controller.advice.exception.HelloNotFoundException;
 import lombok.extern.slf4j.Slf4j;
@@ -83,10 +84,14 @@ public class HelloControllerAdvice {
             builder.append(fieldError.getRejectedValue());
             builder.append("]");
         }
-
         log.error(builder.toString());
-
         return new ResponseEntity<>(error(e), HttpStatus.BAD_REQUEST);
+    }
+
+    @ResponseStatus(HttpStatus.FORBIDDEN)
+    @ExceptionHandler(HelloAuditorAwareException.class)
+    public ResponseEntity<?> handleHelloAuditorAwareException(HelloAuditorAwareException e) {
+        return new ResponseEntity<>(error(e), HttpStatus.FORBIDDEN);
     }
 
     @ResponseStatus(HttpStatus.NOT_FOUND)
@@ -106,5 +111,6 @@ public class HelloControllerAdvice {
     public ResponseEntity<?> handleRuntimeException(RuntimeException e) {
         return new ResponseEntity<>(error(e), HttpStatus.INTERNAL_SERVER_ERROR);
     }
+
 
 }

--- a/src/main/java/com/dykim/base/hello/v1/controller/advice/exception/HelloAuditorAwareException.java
+++ b/src/main/java/com/dykim/base/hello/v1/controller/advice/exception/HelloAuditorAwareException.java
@@ -1,0 +1,9 @@
+package com.dykim.base.hello.v1.controller.advice.exception;
+
+public class HelloAuditorAwareException extends RuntimeException {
+
+    public HelloAuditorAwareException(String msg) {
+        super(msg);
+    }
+
+}

--- a/src/main/java/com/dykim/base/hello/v1/entity/Hello.java
+++ b/src/main/java/com/dykim/base/hello/v1/entity/Hello.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
+import org.hibernate.annotations.Comment;
 import org.hibernate.annotations.DynamicUpdate;
 
 import javax.persistence.*;
@@ -27,26 +28,32 @@ import java.util.Objects;
 @Getter
 @NoArgsConstructor
 @Entity
-public class Hello {
+public class Hello extends HelloBaseEntity {
 
+    @Comment("Hello ID")
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Comment("Hello 이메일")
     @Email
     @Column(length = 100, nullable = false, unique = true)
     private String email;
 
+    @Comment("Hello 명")
     @NotBlank
     @Column(length = 50, nullable = false)
     private String name;
 
+    @Comment("Hello 생년월일")
     @Column(length = 10)
     private LocalDate birthday;
 
+    @Comment("Hello 날짜")
     @Column(length = 23, nullable = false)
     private LocalDateTime yyyyMMddHHmmssSSS;
 
+    @Comment("Hello 사용여부")
     @Column(length = 1, nullable = false)
     private String useYn;
 

--- a/src/main/java/com/dykim/base/hello/v1/entity/HelloBaseEntity.java
+++ b/src/main/java/com/dykim/base/hello/v1/entity/HelloBaseEntity.java
@@ -1,0 +1,29 @@
+package com.dykim.base.hello.v1.entity;
+
+import lombok.Getter;
+import org.hibernate.annotations.Comment;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+@Getter
+public class HelloBaseEntity {
+
+    @Comment("hello 등록시간, yyyyMMddHHmmSSS")
+    @CreatedDate
+    @Column(length = 23, nullable = false, updatable = false)
+    private LocalDateTime createdDateTime;
+
+    @Comment("hello 수정시간, yyyyMMddHHmmSSS")
+    @LastModifiedDate
+    @Column(length = 23, nullable = false)
+    private LocalDateTime updateDateTime;
+
+}

--- a/src/main/java/com/dykim/base/hello/v1/entity/HelloBaseEntity.java
+++ b/src/main/java/com/dykim/base/hello/v1/entity/HelloBaseEntity.java
@@ -2,7 +2,9 @@ package com.dykim.base.hello.v1.entity;
 
 import lombok.Getter;
 import org.hibernate.annotations.Comment;
+import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -16,14 +18,24 @@ import java.time.LocalDateTime;
 @Getter
 public class HelloBaseEntity {
 
+    @Comment("hello 등록자 ID")
+    @CreatedBy
+    @Column(nullable = false, updatable = false)
+    private Long createdId;
+
     @Comment("hello 등록시간, yyyyMMddHHmmSSS")
     @CreatedDate
-    @Column(length = 23, nullable = false, updatable = false)
+    @Column(nullable = false, length = 23, updatable = false)
     private LocalDateTime createdDateTime;
+
+    @Comment("hello 수정자 ID")
+    @LastModifiedBy
+    @Column(nullable = false, updatable = false)
+    private Long updatedId;
 
     @Comment("hello 수정시간, yyyyMMddHHmmSSS")
     @LastModifiedDate
-    @Column(length = 23, nullable = false)
-    private LocalDateTime updateDateTime;
+    @Column(nullable = false, length = 23)
+    private LocalDateTime updatedDateTime;
 
 }

--- a/src/main/java/com/dykim/base/hello/v1/entity/HelloRepository.java
+++ b/src/main/java/com/dykim/base/hello/v1/entity/HelloRepository.java
@@ -8,4 +8,6 @@ public interface HelloRepository extends JpaRepository<Hello, Long> {
 
     Optional<Boolean> existsByEmailAndUseYn(String email, String useYn);
 
+    Optional<Hello> findByIdAndUseYn(Long id, String useYn);
+
 }

--- a/src/main/java/com/dykim/base/hello/v1/service/HelloService.java
+++ b/src/main/java/com/dykim/base/hello/v1/service/HelloService.java
@@ -51,8 +51,6 @@ public class HelloService {
                     throw new HelloAlreadyExistException(
                             String.format("Email '%s' already exists.", reqDto.getEmail()));
                 });
-
-
         var hello = reqDto.toEntity().insert();
         return new HelloInsertRspDto(helloRepository.save(hello));
     }
@@ -68,15 +66,17 @@ public class HelloService {
     }
 
     public HelloUpdateRspDto update(Long id, HelloUpdateReqDto reqDto) {
-        return helloRepository.findById(id)
+        return helloRepository.findByIdAndUseYn(id, "Y")
                 .map(hello -> hello.update(reqDto))
+                .map(helloRepository::save)
                 .map(HelloUpdateRspDto::new)
                 .orElseThrow(() -> new HelloNotFoundException("Not Found Hello. id: " + id));
     }
 
     public HelloDeleteRspDto delete(Long id) {
-        return helloRepository.findById(id)
+        return helloRepository.findByIdAndUseYn(id, "Y")
                 .map(Hello::delete)
+                .map(helloRepository::save)
                 .map(HelloDeleteRspDto::new)
                 .orElseThrow(() -> new HelloNotFoundException("Not Found Hello. id: " + id));
     }

--- a/src/test/java/com/dykim/base/hello/v1/controller/HelloControllerTest.java
+++ b/src/test/java/com/dykim/base/hello/v1/controller/HelloControllerTest.java
@@ -304,7 +304,8 @@ public class HelloControllerTest {
                 .build();
         var reqJson = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(reqDto);
         final var ANY_HELLO_ID = 1;
-        given(helloRepository.findById(any())).willReturn(Optional.of(hello));
+        given(helloRepository.findByIdAndUseYn(any(), any())).willReturn(Optional.of(hello));
+        given(helloRepository.save(any())).willReturn(hello);
 
         // when
         mockMvc.perform(post("/hello/v1/" + ANY_HELLO_ID)
@@ -348,7 +349,8 @@ public class HelloControllerTest {
                 .yyyyMMddHHmmssSSS(yyyyMMddHHmmssSSS)
                 .build();
         final var ANY_HELLO_ID = 1;
-        given(helloRepository.findById(any())).willReturn(Optional.of(hello));
+        given(helloRepository.findByIdAndUseYn(any(), any())).willReturn(Optional.of(hello));
+        given(helloRepository.save(any())).willReturn(hello);
 
         // when
         mockMvc.perform(delete("/hello/v1/" + ANY_HELLO_ID))

--- a/src/test/java/com/dykim/base/hello/v1/entity/HelloRepositoryTest.java
+++ b/src/test/java/com/dykim/base/hello/v1/entity/HelloRepositoryTest.java
@@ -50,6 +50,7 @@ public class HelloRepositoryTest {
         assertThat(hello.getEmail()).isEqualTo(mockHello.getEmail());
         assertThat(hello.getName()).isEqualTo(mockHello.getName());
         assertThat(hello.getBirthday()).isEqualTo(mockHello.getBirthday());
+        assertBaseEntityFind(hello);
     }
 
     @Order(2)
@@ -80,11 +81,13 @@ public class HelloRepositoryTest {
         assertThat(hello1.getEmail()).isEqualTo(mockHello1.getEmail());
         assertThat(hello1.getName()).isEqualTo(mockHello1.getName());
         assertThat(hello1.getBirthday()).isEqualTo(mockHello1.getBirthday());
+        assertBaseEntityFind(hello1);
 
         var hello2 = helloList.get(1);
         assertThat(hello2.getEmail()).isEqualTo(mockHello2.getEmail());
         assertThat(hello2.getName()).isEqualTo(mockHello2.getName());
         assertThat(hello2.getBirthday()).isEqualTo(mockHello2.getBirthday());
+        assertBaseEntityFind(hello2);
     }
 
     @Order(3)
@@ -107,6 +110,7 @@ public class HelloRepositoryTest {
         assertThat(insertedHello.getEmail()).isEqualTo(hello.getEmail());
         assertThat(insertedHello.getName()).isEqualTo(hello.getName());
         assertThat(insertedHello.getBirthday()).isEqualTo(hello.getBirthday());
+        assertBaseEntitySave(insertedHello);
     }
 
     @Order(4)
@@ -176,6 +180,7 @@ public class HelloRepositoryTest {
         assertThat(hello.getId()).isEqualTo(mockHello.getId());
         assertThat(hello.getName()).isEqualTo(helloUpdateReqDto.getName());
         assertThat(hello.getBirthday()).isEqualTo(helloUpdateReqDto.getBirthday());
+        assertBaseEntityUpdate(hello);
 
         var findHelloOps = helloRepository.findById(hello.getId());
         assertThat(findHelloOps.isPresent()).isTrue();
@@ -183,6 +188,7 @@ public class HelloRepositoryTest {
         var findHello = findHelloOps.get();
         assertThat(findHello.getName()).isEqualTo(helloUpdateReqDto.getName());
         assertThat(findHello.getBirthday()).isEqualTo(helloUpdateReqDto.getBirthday());
+        assertBaseEntityFind(findHello);
     }
 
     @Order(7)
@@ -206,12 +212,14 @@ public class HelloRepositoryTest {
         // then
         assertThat(hello.getId()).isEqualTo(mockHello.getId());
         assertThat(hello.getUseYn()).isEqualTo("N");
+        assertBaseEntityDelete(hello);
 
         var findHelloOps = helloRepository.findById(mockHello.getId());
         assertThat(findHelloOps.isPresent()).isTrue();
 
         var findHello = findHelloOps.get();
         assertThat(findHello.getUseYn()).isEqualTo("N");
+        assertBaseEntityFind(findHello);
     }
 
     private LocalDateTime nowYyyyMMddHHmmssSSS() {
@@ -219,6 +227,43 @@ public class HelloRepositoryTest {
         return LocalDateTime.parse(
                 LocalDateTime.now().format(localDateTimeFormat), localDateTimeFormat
         );
+    }
+
+    private void assertBaseEntitySave(Hello hello) {
+        assertBaseEntity(hello, "SAVE");
+    }
+
+    private void assertBaseEntityFind(Hello hello) {
+        assertBaseEntity(hello, "FIND");
+    }
+
+    private void assertBaseEntityUpdate(Hello hello) {
+        assertBaseEntity(hello, "UPDATE");
+    }
+
+    private void assertBaseEntityDelete(Hello hello) {
+        assertBaseEntity(hello, "DELETE");
+    }
+
+    private void assertBaseEntity(Hello hello, String type) {
+        // then
+        // 1) common
+        assertThat(hello.getCreatedDateTime()).isNotNull();
+        assertThat(hello.getUpdateDateTime()).isNotNull();
+
+        // 2) each case
+        switch(type) {
+            case "SAVE":
+                assertThat(hello.getUpdateDateTime()).isEqualTo(hello.getCreatedDateTime());
+                break;
+            case "FIND":
+            case "UPDATE":
+            case "DELETE":
+                assertThat(hello.getUpdateDateTime()).isAfterOrEqualTo(hello.getCreatedDateTime());
+                break;
+            default:
+                assert false;
+        }
     }
 
 }


### PR DESCRIPTION
## #9

## PR 설명
- JPA Auditing 추가

## 변경된 내용
- Hello Entity 기준 JPA Auditing 적용
- 적용 정보
   ```java
   @EntityListeners(AuditingEntityListener.class)
   @MappedSuperclass
   @Getter
   public class HelloBaseEntity {

       @Comment("hello 등록자 ID")
       @CreatedBy
       @Column(nullable = false, updatable = false)
       private Long createdId;

       @Comment("hello 등록시간, yyyyMMddHHmmSSS")
       @CreatedDate
       @Column(nullable = false, length = 23, updatable = false)
       private LocalDateTime createdDateTime;

       @Comment("hello 수정자 ID")
       @LastModifiedBy
       @Column(nullable = false, updatable = false)
       private Long updatedId;

       @Comment("hello 수정시간, yyyyMMddHHmmSSS")
       @LastModifiedDate
       @Column(nullable = false, length = 23)
       private LocalDateTime updatedDateTime;

   }
   ```

## 추가적인 정보
- Auditor 를 설정할 세션이 없어 목데이터로 임시 삽입함.
- **추후 로그인 구현 후 코드 수정 필요(아래와 같이 TODO 로 표기함.)**
   ```java
   @RequiredArgsConstructor
   @Component
   public class HelloAuditorAware implements AuditorAware<Long> {

       /**
        * TODO: 로그인 구현 후 아래 세션 객체 사용필요.
        * HttpSession: 인터셉터를 통해 세션 검증 후 들어오기 때문에 리퀘스트부터 검증할 필요는 없음.<p/>
        * HttpServletRequest: invalid 세션인 경우 HttpSession 바로 사용 시 예외가 발생하기 때문에 검증이 필요할 수도 있음.<p/>
        * 위 케이스를 대비하여 두 가지 객체를 주석으로 추가함.
        */
   //    private HttpSession httpSession;
   //    private HttpServletRequest httpServletRequest;

       @Override
       public Optional<Long> getCurrentAuditor() {
           final var MOCK_SESSION_USER_ID = 2483L;
           return Optional.of(MOCK_SESSION_USER_ID);
       }

   }
   ```